### PR TITLE
Adds a Colorize Module to be used in Logger

### DIFF
--- a/lib/generators/stimulus_reflex/templates/config/initializers/stimulus_reflex.rb
+++ b/lib/generators/stimulus_reflex/templates/config/initializers/stimulus_reflex.rb
@@ -16,5 +16,5 @@ StimulusReflex.configure do |config|
   # You can also use attributes from your ActionCable Connection's identifiers that resolve to valid ActiveRecord models
   # eg. if your connection is `identified_by :current_user` and your User model has an :email attribute, you can pass :email ... it will display `-` if the user isn't logged in
 
-  # config.logging = ->(r) { "#{r.timestamp} #{r.red} [#{r.session_id}] #{r.magenta} #{r.operation_counter} #{r.green} #{r.reflex_info} -> #{r.white} ##{r.selector} #{r.yellow} #{r.operation} #{r.white} via #{r.blue} #{r.mode} Morph #{r.cyan} to #{r.connection_id}" }
+  # config.logging = ->(r) { "#{r.timestamp} [#{r.session_id.red}] #{r.operation_counter.magenta} #{r.reflex_info.green} -> ##{r.selector.white} #{r.operation.yellow} via #{r.mode.blue} Morph #{"to #{r.connection_id}".cyan} " }
 end

--- a/lib/stimulus_reflex.rb
+++ b/lib/stimulus_reflex.rb
@@ -17,6 +17,7 @@ require "stimulus_reflex/broadcasters/broadcaster"
 require "stimulus_reflex/broadcasters/nothing_broadcaster"
 require "stimulus_reflex/broadcasters/page_broadcaster"
 require "stimulus_reflex/broadcasters/selector_broadcaster"
+require "stimulus_reflex/utils/colorize"
 require "stimulus_reflex/logger"
 
 module StimulusReflex

--- a/lib/stimulus_reflex/configuration.rb
+++ b/lib/stimulus_reflex/configuration.rb
@@ -15,11 +15,12 @@ module StimulusReflex
 
   class Configuration
     attr_accessor :on_failed_sanity_checks, :parent_channel, :logging
+    DEFAULT_LOGGING = ->(r) { "#{r.timestamp} [#{r.session_id.red}] #{r.operation_counter.magenta} #{r.reflex_info.green} -> ##{r.selector.white} #{r.operation.yellow} via #{r.mode.blue} Morph #{"to #{r.connection_id}".cyan} " }
 
     def initialize
       @on_failed_sanity_checks = :exit
       @parent_channel = "ApplicationCable::Channel"
-      @logging = ->(r) { "#{r.timestamp} #{r.red} [#{r.session_id}] #{r.magenta} #{r.operation_counter} #{r.green} #{r.reflex_info} -> #{r.white} ##{r.selector} #{r.yellow} #{r.operation} #{r.white} via #{r.blue} #{r.mode} Morph #{r.cyan} to #{r.connection_id}" }
+      @logging = DEFAULT_LOGGING # lambda needs to be on class level to get the right binding to allow for `using Colorize`
     end
   end
 end

--- a/lib/stimulus_reflex/logger.rb
+++ b/lib/stimulus_reflex/logger.rb
@@ -4,16 +4,6 @@ module StimulusReflex
   class Logger
     attr_accessor :reflex, :current_operation
 
-    COLORS = {
-      red: "31",
-      green: "32",
-      yellow: "33",
-      blue: "34",
-      magenta: "35",
-      cyan: "36",
-      white: "37"
-    }
-
     def initialize(reflex)
       @reflex = reflex
       @current_operation = 1
@@ -22,13 +12,20 @@ module StimulusReflex
     def print
       puts
       reflex.broadcaster.operations.each do
-        puts StimulusReflex.config.logging.call(self) + "\e[0m"
+        puts config_logging.call(self) + "\e[0m"
         @current_operation += 1
       end
       puts
     end
 
     private
+
+    def config_logging
+      return @config_logging if @config_logging
+
+      StimulusReflex.config.logging.binding.eval("using StimulusReflex::Utils::Colorize")
+      @config_logging = StimulusReflex.config.logging
+    end
 
     def session_id_full
       session = reflex.request&.session
@@ -60,7 +57,7 @@ module StimulusReflex
     end
 
     def operation
-      reflex.broadcaster.operations[current_operation - 1][1]
+      reflex.broadcaster.operations[current_operation - 1][1].to_s
     end
 
     def operation_counter
@@ -78,10 +75,6 @@ module StimulusReflex
 
     def timestamp
       Time.now.strftime("%Y-%m-%d %H:%M:%S")
-    end
-
-    COLORS.each do |name, code|
-      define_method(name) { "\e[#{code}m" }
     end
 
     def method_missing method

--- a/lib/stimulus_reflex/utils/colorize.rb
+++ b/lib/stimulus_reflex/utils/colorize.rb
@@ -1,0 +1,21 @@
+module StimulusReflex
+  module Utils
+    module Colorize
+      COLORS = {
+        red: "31",
+        green: "32",
+        yellow: "33",
+        blue: "34",
+        magenta: "35",
+        cyan: "36",
+        white: "37"
+      }
+
+      refine String do
+        COLORS.each do |name, code|
+          define_method(name) { "\e[#{code}m#{self}\e[0m" }
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
The module refines `String` with some color methods. In order to use it one has
to put `using StimulusReflex::Utils::Colorize` in the correct context.

## Why should this be added

Makes for a much nicer api to color stuff, you can now:

```ruby
config.logger = -> (r) { r.timestamp.red }
````
## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
