### PR TITLE
Allow logger to use instance methods directly with a proc

### DIFF
--- a/lib/generators/stimulus_reflex/templates/config/initializers/stimulus_reflex.rb
+++ b/lib/generators/stimulus_reflex/templates/config/initializers/stimulus_reflex.rb
@@ -16,5 +16,5 @@ StimulusReflex.configure do |config|
   # You can also use attributes from your ActionCable Connection's identifiers that resolve to valid ActiveRecord models
   # eg. if your connection is `identified_by :current_user` and your User model has an email attribute, you can access r.email (it will display `-` if the user isn't logged in)
 
-  # config.logging = ->(r) { "[#{r.session_id}] #{r.operation_counter.magenta} #{r.reflex_info.green} -> #{r.selector.cyan} via #{r.mode} Morph (#{r.operation.yellow})" }
+  # config.logging = proc { "[#{session_id}] #{operation_counter.magenta} #{reflex_info.green} -> #{selector.cyan} via #{mode} Morph (#{operation.yellow})" }
 end

--- a/lib/stimulus_reflex/configuration.rb
+++ b/lib/stimulus_reflex/configuration.rb
@@ -16,7 +16,7 @@ module StimulusReflex
   class Configuration
     attr_accessor :on_failed_sanity_checks, :parent_channel, :logging
 
-    DEFAULT_LOGGING = ->(r) { "[#{r.session_id}] #{r.operation_counter.magenta} #{r.reflex_info.green} -> #{r.selector.cyan} via #{r.mode} Morph (#{r.operation.yellow})" }
+    DEFAULT_LOGGING = proc { "[#{session_id}] #{operation_counter.magenta} #{reflex_info.green} -> #{selector.cyan} via #{mode} Morph (#{operation.yellow})" }
 
     def initialize
       @on_failed_sanity_checks = :exit

--- a/lib/stimulus_reflex/logger.rb
+++ b/lib/stimulus_reflex/logger.rb
@@ -10,11 +10,11 @@ module StimulusReflex
     end
 
     def print
-      return unless config_logging.lambda?
+      return unless config_logging.instance_of?(Proc)
 
       puts
       reflex.broadcaster.operations.each do
-        puts config_logging.call(self) + "\e[0m"
+        puts instance_eval(&config_logging) + "\e[0m"
         @current_operation += 1
       end
       puts


### PR DESCRIPTION
Instance eval passes the current logger instance directly into the proc,
so the config_logging proc can use those methods directly.

I think this way we have an even nicer api to define the logger. What do you think @piotrwodz @leastbad?